### PR TITLE
feat(api): add core user tables

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -8,6 +8,11 @@ import { HealthModule } from './modules/health/health.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DocsModule } from './modules/docs/docs.module';
+import { RolesModule } from './modules/roles/roles.module';
+import { DesignationsModule } from './modules/designations/designations.module';
+import { TeamsModule } from './modules/teams/teams.module';
+import { UserProfilesModule } from './modules/user-profiles/user-profiles.module';
+import { OauthAccountsModule } from './modules/oauth-accounts/oauth-accounts.module';
 
 @Module({
   imports: [
@@ -19,6 +24,11 @@ import { DocsModule } from './modules/docs/docs.module';
     }),
     DatabaseModule,
     UsersModule,
+    RolesModule,
+    DesignationsModule,
+    TeamsModule,
+    UserProfilesModule,
+    OauthAccountsModule,
     HealthModule,
     DocsModule,
   ],

--- a/apps/api/src/db/designations.schema.ts
+++ b/apps/api/src/db/designations.schema.ts
@@ -1,0 +1,12 @@
+import { pgTable, bigserial, varchar, text, timestamp } from 'drizzle-orm/pg-core';
+
+export const designations = pgTable('designations', {
+  id: bigserial('id', { mode: 'number' }).primaryKey(),
+  name: varchar('name', { length: 100 }).notNull().unique(),
+  description: text('description'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type Designation = typeof designations.$inferSelect;
+export type NewDesignation = typeof designations.$inferInsert;

--- a/apps/api/src/db/oauth-accounts.schema.ts
+++ b/apps/api/src/db/oauth-accounts.schema.ts
@@ -1,0 +1,31 @@
+import {
+  pgTable,
+  bigserial,
+  bigint,
+  varchar,
+  text,
+  timestamp,
+  json,
+} from 'drizzle-orm/pg-core';
+import { users } from './users.schema';
+
+export const oauthAccounts = pgTable('oauth_accounts', {
+  id: bigserial('id', { mode: 'number' }).primaryKey(),
+  userId: bigint('user_id', { mode: 'number' })
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  provider: varchar('provider', { length: 50 }).notNull(),
+  providerUserId: varchar('provider_user_id', { length: 255 }).notNull(),
+  providerEmail: varchar('provider_email', { length: 255 }),
+  avatar: varchar('avatar', { length: 255 }),
+  accessToken: text('access_token').notNull(),
+  refreshToken: text('refresh_token'),
+  expiresAt: timestamp('expires_at', { withTimezone: true }),
+  scopes: text('scopes'),
+  rawPayload: json('raw_payload'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type OauthAccount = typeof oauthAccounts.$inferSelect;
+export type NewOauthAccount = typeof oauthAccounts.$inferInsert;

--- a/apps/api/src/db/roles.schema.ts
+++ b/apps/api/src/db/roles.schema.ts
@@ -1,0 +1,18 @@
+import { pgTable, bigserial, varchar, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
+
+export const roles = pgTable(
+  'roles',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    name: varchar('name', { length: 255 }).notNull(),
+    guardName: varchar('guard_name', { length: 50 }).notNull().default('web'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    nameGuardIdx: uniqueIndex('roles_name_guard_index').on(table.name, table.guardName),
+  }),
+);
+
+export type Role = typeof roles.$inferSelect;
+export type NewRole = typeof roles.$inferInsert;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,2 +1,6 @@
 export * from './users.schema';
-
+export * from './user-profiles.schema';
+export * from './oauth-accounts.schema';
+export * from './roles.schema';
+export * from './designations.schema';
+export * from './teams.schema';

--- a/apps/api/src/db/seed.ts
+++ b/apps/api/src/db/seed.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { createDb, createPool } from './index';
-import { users } from './users.schema';
+import { roles } from './roles.schema';
 
 async function main() {
   const url = process.env.DATABASE_URL;
@@ -9,9 +9,14 @@ async function main() {
   const pool = createPool(url);
   const db = createDb(pool);
 
-  await db.insert(users).values([
-    { email: 'alice@example.com', name: 'Alice' },
-    { email: 'bob@example.com', name: 'Bob' },
+  await db.insert(roles).values([
+    { name: 'Super User' },
+    { name: 'Admin (CEO/COO)' },
+    { name: 'Team Leader' },
+    { name: 'Coordinator' },
+    { name: 'Executive' },
+    { name: 'Engineer' },
+    { name: 'Field' },
   ]);
 
   await pool.end();
@@ -24,4 +29,3 @@ main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
-

--- a/apps/api/src/db/teams.schema.ts
+++ b/apps/api/src/db/teams.schema.ts
@@ -1,0 +1,12 @@
+import { pgTable, bigserial, varchar, bigint, timestamp } from 'drizzle-orm/pg-core';
+
+export const teams = pgTable('teams', {
+  id: bigserial('id', { mode: 'number' }).primaryKey(),
+  name: varchar('name', { length: 100 }).notNull(),
+  parentId: bigint('parent_id', { mode: 'number' }).references(() => teams.id),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type Team = typeof teams.$inferSelect;
+export type NewTeam = typeof teams.$inferInsert;

--- a/apps/api/src/db/user-profiles.schema.ts
+++ b/apps/api/src/db/user-profiles.schema.ts
@@ -1,0 +1,39 @@
+import {
+  pgTable,
+  bigserial,
+  bigint,
+  varchar,
+  date,
+  timestamp,
+} from 'drizzle-orm/pg-core';
+import { users } from './users.schema';
+import { designations } from './designations.schema';
+import { teams } from './teams.schema';
+
+export const userProfiles = pgTable('user_profiles', {
+  id: bigserial('id', { mode: 'number' }).primaryKey(),
+  userId: bigint('user_id', { mode: 'number' })
+    .notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  firstName: varchar('first_name', { length: 255 }),
+  lastName: varchar('last_name', { length: 255 }),
+  dateOfBirth: date('date_of_birth'),
+  gender: varchar('gender', { length: 20 }),
+  employeeCode: varchar('employee_code', { length: 50 }).unique(),
+  designationId: bigint('designation_id', { mode: 'number' }).references(() => designations.id),
+  primaryTeamId: bigint('primary_team_id', { mode: 'number' }).references(() => teams.id),
+  altEmail: varchar('alt_email', { length: 255 }),
+  emergencyContactName: varchar('emergency_contact_name', { length: 255 }),
+  emergencyContactPhone: varchar('emergency_contact_phone', { length: 20 }),
+  image: varchar('image', { length: 255 }),
+  signature: varchar('signature', { length: 255 }),
+  dateOfJoining: date('date_of_joining'),
+  dateOfExit: date('date_of_exit'),
+  timezone: varchar('timezone', { length: 50 }).notNull().default('Asia/Kolkata'),
+  locale: varchar('locale', { length: 10 }).notNull().default('en'),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type UserProfile = typeof userProfiles.$inferSelect;
+export type NewUserProfile = typeof userProfiles.$inferInsert;

--- a/apps/api/src/db/users.schema.ts
+++ b/apps/api/src/db/users.schema.ts
@@ -1,16 +1,33 @@
-import { pgTable, serial, varchar, timestamp, boolean } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  bigserial,
+  varchar,
+  timestamp,
+  boolean,
+  index,
+} from 'drizzle-orm/pg-core';
 
-export const users = pgTable('users', {
-  id: serial('id').primaryKey(),
-  email: varchar('email', { length: 255 }).notNull().unique(),
-  name: varchar('name', { length: 255 }),
-  isActive: boolean('is_active').notNull().default(true),
-  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-  updatedAt: timestamp('updated_at', { withTimezone: true })
-    .notNull()
-    .defaultNow(),
-});
+export const users = pgTable(
+  'users',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    name: varchar('name', { length: 255 }).notNull(),
+    username: varchar('username', { length: 100 }).unique(),
+    email: varchar('email', { length: 255 }).notNull().unique(),
+    mobile: varchar('mobile', { length: 20 }),
+    password: varchar('password', { length: 255 }).notNull(),
+    emailVerifiedAt: timestamp('email_verified_at', { withTimezone: true }),
+    lastLoginAt: timestamp('last_login_at', { withTimezone: true }),
+    isActive: boolean('is_active').notNull().default(true),
+    rememberToken: varchar('remember_token', { length: 255 }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
+  },
+  (table) => ({
+    mobileIdx: index('users_mobile_idx').on(table.mobile),
+  }),
+);
 
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
-

--- a/apps/api/src/modules/designations/designations.controller.ts
+++ b/apps/api/src/modules/designations/designations.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { z } from 'zod';
+import { DesignationsService } from './designations.service';
+
+const CreateDesignationSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+});
+
+type CreateDesignationDto = z.infer<typeof CreateDesignationSchema>;
+
+@Controller('designations')
+export class DesignationsController {
+  constructor(private readonly designationsService: DesignationsService) {}
+
+  @Get()
+  async list() {
+    return this.designationsService.findAll();
+  }
+
+  @Post()
+  async create(@Body() body: unknown) {
+    const parsed = CreateDesignationSchema.parse(body) as CreateDesignationDto;
+    return this.designationsService.create(parsed);
+  }
+}

--- a/apps/api/src/modules/designations/designations.module.ts
+++ b/apps/api/src/modules/designations/designations.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
+import { DesignationsService } from './designations.service';
+import { DesignationsController } from './designations.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [DesignationsController],
+  providers: [DesignationsService],
+})
+export class DesignationsModule {}

--- a/apps/api/src/modules/designations/designations.service.ts
+++ b/apps/api/src/modules/designations/designations.service.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DRIZZLE } from '../../database/database.module';
+import type { DbInstance } from '../../db';
+import {
+  designations,
+  type NewDesignation,
+  type Designation,
+} from '../../db/designations.schema';
+
+@Injectable()
+export class DesignationsService {
+  constructor(@Inject(DRIZZLE) private readonly db: DbInstance) {}
+
+  async findAll(): Promise<Designation[]> {
+    return this.db.select().from(designations);
+  }
+
+  async create(data: NewDesignation): Promise<Designation> {
+    const [created] = await this.db.insert(designations).values(data).returning();
+    return created;
+  }
+}

--- a/apps/api/src/modules/oauth-accounts/oauth-accounts.controller.ts
+++ b/apps/api/src/modules/oauth-accounts/oauth-accounts.controller.ts
@@ -1,0 +1,37 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { z } from 'zod';
+import { OauthAccountsService } from './oauth-accounts.service';
+
+const CreateOauthAccountSchema = z.object({
+  userId: z.number(),
+  provider: z.string().min(1),
+  providerUserId: z.string().min(1),
+  providerEmail: z.string().email().optional(),
+  avatar: z.string().optional(),
+  accessToken: z.string().min(1),
+  refreshToken: z.string().optional(),
+  expiresAt: z.string().optional(),
+  scopes: z.string().optional(),
+  rawPayload: z.any().optional(),
+});
+
+type CreateOauthAccountDto = z.infer<typeof CreateOauthAccountSchema>;
+
+@Controller('oauth-accounts')
+export class OauthAccountsController {
+  constructor(private readonly oauthAccountsService: OauthAccountsService) {}
+
+  @Get()
+  async list() {
+    return this.oauthAccountsService.findAll();
+  }
+
+  @Post()
+  async create(@Body() body: unknown) {
+    const parsed = CreateOauthAccountSchema.parse(body) as CreateOauthAccountDto;
+    if (parsed.expiresAt) {
+      parsed.expiresAt = new Date(parsed.expiresAt) as any;
+    }
+    return this.oauthAccountsService.create(parsed as any);
+  }
+}

--- a/apps/api/src/modules/oauth-accounts/oauth-accounts.module.ts
+++ b/apps/api/src/modules/oauth-accounts/oauth-accounts.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
+import { OauthAccountsService } from './oauth-accounts.service';
+import { OauthAccountsController } from './oauth-accounts.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [OauthAccountsController],
+  providers: [OauthAccountsService],
+})
+export class OauthAccountsModule {}

--- a/apps/api/src/modules/oauth-accounts/oauth-accounts.service.ts
+++ b/apps/api/src/modules/oauth-accounts/oauth-accounts.service.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DRIZZLE } from '../../database/database.module';
+import type { DbInstance } from '../../db';
+import {
+  oauthAccounts,
+  type NewOauthAccount,
+  type OauthAccount,
+} from '../../db/oauth-accounts.schema';
+
+@Injectable()
+export class OauthAccountsService {
+  constructor(@Inject(DRIZZLE) private readonly db: DbInstance) {}
+
+  async findAll(): Promise<OauthAccount[]> {
+    return this.db.select().from(oauthAccounts);
+  }
+
+  async create(data: NewOauthAccount): Promise<OauthAccount> {
+    const [created] = await this.db.insert(oauthAccounts).values(data).returning();
+    return created;
+  }
+}

--- a/apps/api/src/modules/roles/roles.controller.ts
+++ b/apps/api/src/modules/roles/roles.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { z } from 'zod';
+import { RolesService } from './roles.service';
+
+const CreateRoleSchema = z.object({
+  name: z.string().min(1),
+  guardName: z.string().min(1).optional(),
+});
+
+type CreateRoleDto = z.infer<typeof CreateRoleSchema>;
+
+@Controller('roles')
+export class RolesController {
+  constructor(private readonly rolesService: RolesService) {}
+
+  @Get()
+  async list() {
+    return this.rolesService.findAll();
+  }
+
+  @Post()
+  async create(@Body() body: unknown) {
+    const parsed = CreateRoleSchema.parse(body) as CreateRoleDto;
+    return this.rolesService.create(parsed);
+  }
+}

--- a/apps/api/src/modules/roles/roles.module.ts
+++ b/apps/api/src/modules/roles/roles.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
+import { RolesService } from './roles.service';
+import { RolesController } from './roles.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [RolesController],
+  providers: [RolesService],
+})
+export class RolesModule {}

--- a/apps/api/src/modules/roles/roles.service.ts
+++ b/apps/api/src/modules/roles/roles.service.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DRIZZLE } from '../../database/database.module';
+import type { DbInstance } from '../../db';
+import { roles, type NewRole, type Role } from '../../db/roles.schema';
+
+@Injectable()
+export class RolesService {
+  constructor(@Inject(DRIZZLE) private readonly db: DbInstance) {}
+
+  async findAll(): Promise<Role[]> {
+    return this.db.select().from(roles);
+  }
+
+  async create(data: NewRole): Promise<Role> {
+    const [created] = await this.db.insert(roles).values(data).returning();
+    return created;
+  }
+}

--- a/apps/api/src/modules/teams/teams.controller.ts
+++ b/apps/api/src/modules/teams/teams.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { z } from 'zod';
+import { TeamsService } from './teams.service';
+
+const CreateTeamSchema = z.object({
+  name: z.string().min(1),
+  parentId: z.number().optional(),
+});
+
+type CreateTeamDto = z.infer<typeof CreateTeamSchema>;
+
+@Controller('teams')
+export class TeamsController {
+  constructor(private readonly teamsService: TeamsService) {}
+
+  @Get()
+  async list() {
+    return this.teamsService.findAll();
+  }
+
+  @Post()
+  async create(@Body() body: unknown) {
+    const parsed = CreateTeamSchema.parse(body) as CreateTeamDto;
+    return this.teamsService.create(parsed);
+  }
+}

--- a/apps/api/src/modules/teams/teams.module.ts
+++ b/apps/api/src/modules/teams/teams.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
+import { TeamsService } from './teams.service';
+import { TeamsController } from './teams.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [TeamsController],
+  providers: [TeamsService],
+})
+export class TeamsModule {}

--- a/apps/api/src/modules/teams/teams.service.ts
+++ b/apps/api/src/modules/teams/teams.service.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DRIZZLE } from '../../database/database.module';
+import type { DbInstance } from '../../db';
+import { teams, type NewTeam, type Team } from '../../db/teams.schema';
+
+@Injectable()
+export class TeamsService {
+  constructor(@Inject(DRIZZLE) private readonly db: DbInstance) {}
+
+  async findAll(): Promise<Team[]> {
+    return this.db.select().from(teams);
+  }
+
+  async create(data: NewTeam): Promise<Team> {
+    const [created] = await this.db.insert(teams).values(data).returning();
+    return created;
+  }
+}

--- a/apps/api/src/modules/user-profiles/user-profiles.controller.ts
+++ b/apps/api/src/modules/user-profiles/user-profiles.controller.ts
@@ -1,0 +1,41 @@
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { z } from 'zod';
+import { UserProfilesService } from './user-profiles.service';
+
+const CreateUserProfileSchema = z.object({
+  userId: z.number(),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  dateOfBirth: z.string().optional(),
+  gender: z.string().optional(),
+  employeeCode: z.string().optional(),
+  designationId: z.number().optional(),
+  primaryTeamId: z.number().optional(),
+  altEmail: z.string().email().optional(),
+  emergencyContactName: z.string().optional(),
+  emergencyContactPhone: z.string().optional(),
+  image: z.string().optional(),
+  signature: z.string().optional(),
+  dateOfJoining: z.string().optional(),
+  dateOfExit: z.string().optional(),
+  timezone: z.string().optional(),
+  locale: z.string().optional(),
+});
+
+type CreateUserProfileDto = z.infer<typeof CreateUserProfileSchema>;
+
+@Controller('user-profiles')
+export class UserProfilesController {
+  constructor(private readonly userProfilesService: UserProfilesService) {}
+
+  @Get()
+  async list() {
+    return this.userProfilesService.findAll();
+  }
+
+  @Post()
+  async create(@Body() body: unknown) {
+    const parsed = CreateUserProfileSchema.parse(body) as CreateUserProfileDto;
+    return this.userProfilesService.create(parsed);
+  }
+}

--- a/apps/api/src/modules/user-profiles/user-profiles.module.ts
+++ b/apps/api/src/modules/user-profiles/user-profiles.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../database/database.module';
+import { UserProfilesService } from './user-profiles.service';
+import { UserProfilesController } from './user-profiles.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [UserProfilesController],
+  providers: [UserProfilesService],
+})
+export class UserProfilesModule {}

--- a/apps/api/src/modules/user-profiles/user-profiles.service.ts
+++ b/apps/api/src/modules/user-profiles/user-profiles.service.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DRIZZLE } from '../../database/database.module';
+import type { DbInstance } from '../../db';
+import {
+  userProfiles,
+  type NewUserProfile,
+  type UserProfile,
+} from '../../db/user-profiles.schema';
+
+@Injectable()
+export class UserProfilesService {
+  constructor(@Inject(DRIZZLE) private readonly db: DbInstance) {}
+
+  async findAll(): Promise<UserProfile[]> {
+    return this.db.select().from(userProfiles);
+  }
+
+  async create(data: NewUserProfile): Promise<UserProfile> {
+    const [created] = await this.db.insert(userProfiles).values(data).returning();
+    return created;
+  }
+}

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -3,8 +3,11 @@ import { z } from 'zod';
 import { UsersService } from './users.service';
 
 const CreateUserSchema = z.object({
+  name: z.string().min(1),
+  username: z.string().max(100).optional(),
   email: z.string().email(),
-  name: z.string().min(1).optional(),
+  mobile: z.string().max(20).optional(),
+  password: z.string().min(1),
 });
 
 type CreateUserDto = z.infer<typeof CreateUserSchema>;
@@ -21,7 +24,7 @@ export class UsersController {
   @Post()
   async create(@Body() body: unknown) {
     const parsed = CreateUserSchema.parse(body) as CreateUserDto;
-    return this.usersService.create({ email: parsed.email, name: parsed.name });
+    return this.usersService.create(parsed);
   }
 }
 


### PR DESCRIPTION
## Summary
- expand user schema with authentication fields and soft deletes
- add HR and auth-related tables and Nest modules
- seed default roles and expose CRUD endpoints

## Testing
- `pnpm drizzle:generate` *(fails: drizzle-kit: not found)*
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68beaecd796083339df23502b7bf3e29