### PR TITLE
Batch Timer Lookup

### DIFF
--- a/api/src/modules/tendering/bid-submissions/bid-submissions.controller.ts
+++ b/api/src/modules/tendering/bid-submissions/bid-submissions.controller.ts
@@ -1,11 +1,11 @@
-import { Controller, Get, Post, Patch, Body, Param, ParseIntPipe, Query } from '@nestjs/common';
-import { BidSubmissionsService } from '@/modules/tendering/bid-submissions/bid-submissions.service';
-import type { SubmitBidDto, MarkAsMissedDto, UpdateBidSubmissionDto, MarkAsMissedGlobalDto } from './dto/bid-submission.dto';
+import { AppLogger } from '@/logger/app-logger.service';
 import { CurrentUser } from '@/modules/auth/decorators/current-user.decorator';
 import type { ValidatedUser } from '@/modules/auth/strategies/jwt.strategy';
+import { BidSubmissionsService } from '@/modules/tendering/bid-submissions/bid-submissions.service';
+import { getFrontendTimersBatch } from '@/modules/timers/timer-helper';
 import { TimersService } from '@/modules/timers/timers.service';
-import { getFrontendTimer } from '@/modules/timers/timer-helper';
-import { AppLogger } from '@/logger/app-logger.service';
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import type { MarkAsMissedDto, MarkAsMissedGlobalDto, SubmitBidDto, UpdateBidSubmissionDto } from './dto/bid-submission.dto';
 
 @Controller('bid-submissions')
 export class BidSubmissionsController {
@@ -41,19 +41,13 @@ export class BidSubmissionsController {
             sortOrder,
             search,
         });
-        // Add timer data to each tender
-        const dataWithTimers = await Promise.all(
-            result.data.map(async (tender) => {
-                // this.logger.debug(`Fetching timer for tender ${tender.tenderId}, stage bid_submission`);
-                const timer = await getFrontendTimer(this.timersService, 'TENDER', tender.tenderId, 'bid_submission');
-                // this.logger.debug(`Timer for tender ${tender.tenderId}: ${JSON.stringify(timer)}`);
-
-                return {
-                    ...tender,
-                    timer
-                };
-            })
-        );
+        // Batch-fetch timer data for all tenders
+        const tenderIds = result.data.map(t => t.tenderId);
+        const timerMap = await getFrontendTimersBatch(this.timersService, 'TENDER', tenderIds, 'bid_submission');
+        const dataWithTimers = result.data.map(tender => ({
+            ...tender,
+            timer: timerMap.get(tender.tenderId)
+        }));
 
         return {
             ...result,

--- a/api/src/modules/tendering/checklists/document-checklists.controller.ts
+++ b/api/src/modules/tendering/checklists/document-checklists.controller.ts
@@ -1,11 +1,11 @@
-import { Controller, Get, Post, Patch, Body, Param, ParseIntPipe, Query, UsePipes, ValidationPipe } from '@nestjs/common';
-import { DocumentChecklistsService, type DocumentChecklistFilters } from '@/modules/tendering/checklists/document-checklists.service';
-import type { CreateDocumentChecklistDto, UpdateDocumentChecklistDto } from '@/modules/tendering/checklists/dto/document-checklist.dto';
-import { TimersService } from '@/modules/timers/timers.service';
-import { getFrontendTimer } from '@/modules/timers/timer-helper';
+import { AppLogger } from '@/logger/app-logger.service';
 import { CurrentUser } from '@/modules/auth/decorators/current-user.decorator';
 import type { ValidatedUser } from '@/modules/auth/strategies/jwt.strategy';
-import { AppLogger } from '@/logger/app-logger.service';
+import { DocumentChecklistsService } from '@/modules/tendering/checklists/document-checklists.service';
+import type { CreateDocumentChecklistDto, UpdateDocumentChecklistDto } from '@/modules/tendering/checklists/dto/document-checklist.dto';
+import { getFrontendTimersBatch } from '@/modules/timers/timer-helper';
+import { TimersService } from '@/modules/timers/timers.service';
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query, UsePipes, ValidationPipe } from '@nestjs/common';
 
 @Controller('document-checklists')
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
@@ -42,16 +42,13 @@ export class DocumentChecklistsController {
             sortOrder,
             search,
         }, user, parseNumber(teamId));
-        // Add timer data to each tender
-        const dataWithTimers = await Promise.all(
-            result.data.map(async (tender) => {
-                const timer = await getFrontendTimer(this.timersService, 'TENDER', tender.tenderId, 'document_checklist');
-                return {
-                    ...tender,
-                    timer
-                };
-            })
-        );
+        // Batch-fetch timer data for all tenders
+        const tenderIds = result.data.map(t => t.tenderId);
+        const timerMap = await getFrontendTimersBatch(this.timersService, 'TENDER', tenderIds, 'document_checklist');
+        const dataWithTimers = result.data.map(tender => ({
+            ...tender,
+            timer: timerMap.get(tender.tenderId)
+        }));
 
         return {
             ...result,

--- a/api/src/modules/tendering/costing-approvals/costing-approvals.controller.ts
+++ b/api/src/modules/tendering/costing-approvals/costing-approvals.controller.ts
@@ -2,7 +2,7 @@ import { AppLogger } from '@/logger/app-logger.service';
 import { CurrentUser } from '@/modules/auth/decorators/current-user.decorator';
 import type { ValidatedUser } from '@/modules/auth/strategies/jwt.strategy';
 import { CostingApprovalsService } from '@/modules/tendering/costing-approvals/costing-approvals.service';
-import { getFrontendTimer } from '@/modules/timers/timer-helper';
+import { getFrontendTimersBatch } from '@/modules/timers/timer-helper';
 import { TimersService } from '@/modules/timers/timers.service';
 import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
 import type { ApproveAllCostingDto, ApproveCostingDto, RejectCostingDto, UpdateApprovedCostingDto } from './dto/costing-approval.dto';
@@ -41,16 +41,13 @@ export class CostingApprovalsController {
             sortOrder,
             search,
         }, user, parseNumber(teamId));
-        // Add timer data to each tender
-        const dataWithTimers = await Promise.all(
-            result.data.map(async (tender) => {
-                const timer = await getFrontendTimer(this.timersService, 'TENDER', tender.tenderId, 'costing_sheet_approval');
-                return {
-                    ...tender,
-                    timer
-                };
-            })
-        );
+        // Batch-fetch timer data for all tenders
+        const tenderIds = result.data.map(t => t.tenderId);
+        const timerMap = await getFrontendTimersBatch(this.timersService, 'TENDER', tenderIds, 'costing_sheet_approval');
+        const dataWithTimers = result.data.map(tender => ({
+            ...tender,
+            timer: timerMap.get(tender.tenderId)
+        }));
 
         return {
             ...result,

--- a/api/src/modules/tendering/costing-sheets/costing-sheets.controller.ts
+++ b/api/src/modules/tendering/costing-sheets/costing-sheets.controller.ts
@@ -1,11 +1,11 @@
-import { Controller, Get, Post, Patch, Delete, Body, Param, ParseIntPipe, Query } from '@nestjs/common';
-import { CostingSheetsService, type CostingSheetFilters } from '@/modules/tendering/costing-sheets/costing-sheets.service';
-import type { SubmitCostingSheetDto, UpdateCostingSheetDto, CreateSheetDto, CreateSheetWithNameDto } from './dto/costing-sheet.dto';
+import { AppLogger } from '@/logger/app-logger.service';
 import { CurrentUser } from '@/modules/auth/decorators/current-user.decorator';
 import type { ValidatedUser } from '@/modules/auth/strategies/jwt.strategy';
+import { CostingSheetsService } from '@/modules/tendering/costing-sheets/costing-sheets.service';
+import { getFrontendTimersBatch } from '@/modules/timers/timer-helper';
 import { TimersService } from '@/modules/timers/timers.service';
-import { getFrontendTimer } from '@/modules/timers/timer-helper';
-import { AppLogger } from '@/logger/app-logger.service';
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import type { CreateSheetDto, CreateSheetWithNameDto } from './dto/costing-sheet.dto';
 
 @Controller('costing-sheets')
 export class CostingSheetsController {
@@ -41,16 +41,13 @@ export class CostingSheetsController {
             sortOrder,
             search,
         }, user, parseNumber(teamId));
-        // Add timer data to each tender
-        const dataWithTimers = await Promise.all(
-            result.data.map(async (tender) => {
-                const timer = await getFrontendTimer(this.timersService, 'TENDER', tender.tenderId, 'costing_sheet');
-                return {
-                    ...tender,
-                    timer
-                };
-            })
-        );
+        // Batch-fetch timer data for all tenders
+        const tenderIds = result.data.map(t => t.tenderId);
+        const timerMap = await getFrontendTimersBatch(this.timersService, 'TENDER', tenderIds, 'costing_sheet');
+        const dataWithTimers = result.data.map(tender => ({
+            ...tender,
+            timer: timerMap.get(tender.tenderId)
+        }));
 
         return {
             ...result,

--- a/api/src/modules/tendering/payment-requests/payment-requests.controller.ts
+++ b/api/src/modules/tendering/payment-requests/payment-requests.controller.ts
@@ -1,14 +1,14 @@
-import { Body, Controller, Get, HttpCode, HttpStatus, Param, ParseIntPipe, Patch, Post, Query, Res, StreamableFile } from '@nestjs/common';
-import type { Response } from 'express';
-import { PaymentRequestsQueryService } from './services/payment-requests.query.service';
-import { PaymentRequestsCommandService } from './services/payment-requests.command.service';
-import { CreatePaymentRequestSchema, UpdatePaymentRequestSchema, UpdateStatusSchema, DashboardQuerySchema, type DashboardResponse, type DashboardCounts, type DashboardTab } from './dto/payment-requests.dto';
-import { CreateMomRemarkSchema } from './dto/payment-mom.dto';
+import { AppLogger } from '@/logger/app-logger.service';
 import { CurrentUser } from '@/modules/auth/decorators/current-user.decorator';
 import type { ValidatedUser } from '@/modules/auth/strategies/jwt.strategy';
+import { getFrontendTimersBatch } from '@/modules/timers/timer-helper';
 import { TimersService } from '@/modules/timers/timers.service';
-import { getFrontendTimer } from '@/modules/timers/timer-helper';
-import { AppLogger } from '@/logger/app-logger.service';
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, ParseIntPipe, Patch, Post, Query, Res, StreamableFile } from '@nestjs/common';
+import type { Response } from 'express';
+import { CreateMomRemarkSchema } from './dto/payment-mom.dto';
+import { CreatePaymentRequestSchema, DashboardQuerySchema, UpdatePaymentRequestSchema, UpdateStatusSchema, type DashboardCounts, type DashboardResponse, type DashboardTab } from './dto/payment-requests.dto';
+import { PaymentRequestsCommandService } from './services/payment-requests.command.service';
+import { PaymentRequestsQueryService } from './services/payment-requests.query.service';
 
 @Controller('payment-requests')
 export class PaymentRequestsController {
@@ -43,16 +43,13 @@ export class PaymentRequestsController {
             parsed.sortBy ? { sortBy: parsed.sortBy, sortOrder: parsed.sortOrder } : undefined,
             parsed.search
         );
-        // Add timer data to each tender
-        const dataWithTimers = await Promise.all(
-            result.data.map(async (tender: any) => {
-                const timer = await getFrontendTimer(this.timersService, 'TENDER', tender.tenderId, 'emd_request');
-                return {
-                    ...tender,
-                    timer
-                };
-            })
-        );
+        // Batch-fetch timer data for all tenders
+        const tenderIds = result.data.map((t: any) => t.tenderId);
+        const timerMap = await getFrontendTimersBatch(this.timersService, 'TENDER', tenderIds, 'emd_request');
+        const dataWithTimers = result.data.map((tender: any) => ({
+            ...tender,
+            timer: timerMap.get(tender.tenderId)
+        }));
 
         return {
             ...result,

--- a/api/src/modules/tendering/physical-docs/physical-docs.controller.ts
+++ b/api/src/modules/tendering/physical-docs/physical-docs.controller.ts
@@ -1,24 +1,11 @@
-import {
-    Body,
-    Controller,
-    Delete,
-    Get,
-    Param,
-    ParseIntPipe,
-    Patch,
-    Post,
-    HttpCode,
-    HttpStatus,
-    NotFoundException,
-    Query,
-} from '@nestjs/common';
-import { PhysicalDocsService } from '@/modules/tendering/physical-docs/physical-docs.service';
-import type { CreatePhysicalDocDto, UpdatePhysicalDocDto } from '@/modules/tendering/physical-docs/dto/physical-docs.dto';
+import { AppLogger } from '@/logger/app-logger.service';
 import { CurrentUser } from '@/modules/auth/decorators/current-user.decorator';
 import type { ValidatedUser } from '@/modules/auth/strategies/jwt.strategy';
+import type { CreatePhysicalDocDto, UpdatePhysicalDocDto } from '@/modules/tendering/physical-docs/dto/physical-docs.dto';
+import { PhysicalDocsService } from '@/modules/tendering/physical-docs/physical-docs.service';
+import { getFrontendTimersBatch } from '@/modules/timers/timer-helper';
 import { TimersService } from '@/modules/timers/timers.service';
-import { getFrontendTimer } from '@/modules/timers/timer-helper';
-import { AppLogger } from '@/logger/app-logger.service';
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, NotFoundException, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
 
 @Controller('physical-docs')
 export class PhysicalDocsController {
@@ -54,16 +41,13 @@ export class PhysicalDocsController {
             sortOrder,
             search,
         });
-        // Add timer data to each tender
-        const dataWithTimers = await Promise.all(
-            result.data.map(async (tender) => {
-                const timer = await getFrontendTimer(this.timersService, 'TENDER', tender.tenderId, 'physical_docs');
-                return {
-                    ...tender,
-                    timer
-                };
-            })
-        );
+        // Batch-fetch timer data for all tenders
+        const tenderIds = result.data.map(t => t.tenderId);
+        const timerMap = await getFrontendTimersBatch(this.timersService, 'TENDER', tenderIds, 'physical_docs');
+        const dataWithTimers = result.data.map(tender => ({
+            ...tender,
+            timer: timerMap.get(tender.tenderId)
+        }));
 
         return {
             ...result,

--- a/api/src/modules/tendering/rfqs/rfq.controller.ts
+++ b/api/src/modules/tendering/rfqs/rfq.controller.ts
@@ -1,11 +1,11 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, HttpCode, HttpStatus, NotFoundException, Query } from "@nestjs/common";
-import { RfqsService } from "@/modules/tendering/rfqs/rfq.service";
-import type { CreateRfqDto, UpdateRfqDto } from "@/modules/tendering/rfqs/dto/rfq.dto";
+import { AppLogger } from "@/logger/app-logger.service";
 import { CurrentUser } from "@/modules/auth/decorators/current-user.decorator";
 import type { ValidatedUser } from "@/modules/auth/strategies/jwt.strategy";
+import type { CreateRfqDto, UpdateRfqDto } from "@/modules/tendering/rfqs/dto/rfq.dto";
+import { RfqsService } from "@/modules/tendering/rfqs/rfq.service";
+import { getFrontendTimersBatch } from "@/modules/timers/timer-helper";
 import { TimersService } from "@/modules/timers/timers.service";
-import { getFrontendTimer } from "@/modules/timers/timer-helper";
-import { AppLogger } from "@/logger/app-logger.service";
+import { Body, Controller, Delete, Get, HttpCode, HttpStatus, NotFoundException, Param, ParseIntPipe, Patch, Post, Query } from "@nestjs/common";
 
 @Controller("rfqs")
 export class RfqsController {
@@ -41,16 +41,13 @@ export class RfqsController {
             sortOrder,
             search,
         });
-        // Add timer data to each tender
-        const dataWithTimers = await Promise.all(
-            result.data.map(async tender => {
-                const timer = await getFrontendTimer(this.timersService, "TENDER", tender.tenderId, "rfq");
-                return {
-                    ...tender,
-                    timer,
-                };
-            })
-        );
+        // Batch-fetch timer data for all tenders
+        const tenderIds = result.data.map(t => t.tenderId);
+        const timerMap = await getFrontendTimersBatch(this.timersService, 'TENDER', tenderIds, 'rfq');
+        const dataWithTimers = result.data.map(tender => ({
+            ...tender,
+            timer: timerMap.get(tender.tenderId),
+        }));
 
         return {
             ...result,

--- a/api/src/modules/tendering/tender-approval/tender-approval.controller.ts
+++ b/api/src/modules/tendering/tender-approval/tender-approval.controller.ts
@@ -1,11 +1,11 @@
-import { Controller, Get, Put, Param, Body, ParseIntPipe, Query } from '@nestjs/common';
-import { TenderApprovalService, type TenderApprovalFilters } from '@/modules/tendering/tender-approval/tender-approval.service';
-import { TenderApprovalPayloadSchema, type TenderApprovalPayload } from '@/modules/tendering/tender-approval/dto/tender-approval.dto';
+import { AppLogger } from '@/logger/app-logger.service';
 import { CurrentUser } from '@/modules/auth/decorators/current-user.decorator';
 import type { ValidatedUser } from '@/modules/auth/strategies/jwt.strategy';
+import { TenderApprovalPayloadSchema } from '@/modules/tendering/tender-approval/dto/tender-approval.dto';
+import { TenderApprovalService } from '@/modules/tendering/tender-approval/tender-approval.service';
+import { getFrontendTimersBatch } from '@/modules/timers/timer-helper';
 import { TimersService } from '@/modules/timers/timers.service';
-import { getFrontendTimer } from '@/modules/timers/timer-helper';
-import { AppLogger } from '@/logger/app-logger.service';
+import { Body, Controller, Get, Param, ParseIntPipe, Put, Query } from '@nestjs/common';
 
 @Controller('tender-approvals')
 export class TenderApprovalController {
@@ -41,16 +41,13 @@ export class TenderApprovalController {
             sortOrder,
             search,
         });
-        // Add timer data to each tender
-        const dataWithTimers = await Promise.all(
-            result.data.map(async (tender) => {
-                const timer = await getFrontendTimer(this.timersService, 'TENDER', tender.tenderId, 'tender_approval');
-                return {
-                    ...tender,
-                    timer
-                };
-            })
-        );
+        // Batch-fetch timer data for all tenders
+        const tenderIds = result.data.map(t => t.tenderId);
+        const timerMap = await getFrontendTimersBatch(this.timersService, 'TENDER', tenderIds, 'tender_approval');
+        const dataWithTimers = result.data.map(tender => ({
+            ...tender,
+            timer: timerMap.get(tender.tenderId)
+        }));
 
         return {
             ...result,

--- a/api/src/modules/tendering/tq-management/tq-management.controller.ts
+++ b/api/src/modules/tendering/tq-management/tq-management.controller.ts
@@ -1,18 +1,11 @@
-import { Controller, Get, Post, Patch, Body, Param, ParseIntPipe, Query } from '@nestjs/common';
-import { TqManagementService, type TqManagementFilters, type TenderQueryStatus } from '@/modules/tendering/tq-management/tq-management.service';
-import type {
-    CreateTqReceivedDto,
-    UpdateTqRepliedDto,
-    UpdateTqMissedDto,
-    MarkAsNoTqDto,
-    UpdateTqReceivedDto,
-    TqQualifiedDto
-} from './dto/tq-management.dto';
+import { AppLogger } from '@/logger/app-logger.service';
 import { CurrentUser } from '@/modules/auth/decorators/current-user.decorator';
 import type { ValidatedUser } from '@/modules/auth/strategies/jwt.strategy';
+import { TqManagementService } from '@/modules/tendering/tq-management/tq-management.service';
+import { getFrontendTimersBatch } from '@/modules/timers/timer-helper';
 import { TimersService } from '@/modules/timers/timers.service';
-import { getFrontendTimer } from '@/modules/timers/timer-helper';
-import { AppLogger } from '@/logger/app-logger.service';
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import type { CreateTqReceivedDto, MarkAsNoTqDto, TqQualifiedDto, UpdateTqMissedDto, UpdateTqReceivedDto, UpdateTqRepliedDto } from './dto/tq-management.dto';
 
 @Controller('tq-management')
 export class TqManagementController {
@@ -52,16 +45,13 @@ export class TqManagementController {
             sortOrder,
             search,
         });
-        // Add timer data to each tender
-        const dataWithTimers = await Promise.all(
-            result.data.map(async (tender) => {
-                const timer = await getFrontendTimer(this.timersService, 'TENDER', tender.tenderId, 'tq_replied');
-                return {
-                    ...tender,
-                    timer
-                };
-            })
-        );
+        // Batch-fetch timer data for all tenders
+        const tenderIds = result.data.map(t => t.tenderId);
+        const timerMap = await getFrontendTimersBatch(this.timersService, 'TENDER', tenderIds, 'tq_replied');
+        const dataWithTimers = result.data.map(tender => ({
+            ...tender,
+            timer: timerMap.get(tender.tenderId)
+        }));
 
         return {
             ...result,

--- a/api/src/modules/timers/timer-helper.ts
+++ b/api/src/modules/timers/timer-helper.ts
@@ -1,5 +1,5 @@
 import type { TimersService } from './timers.service';
-import { transformTimerForFrontend } from './timer-transform';
+import { transformTimerForFrontend, type FrontendTimerData } from './timer-transform';
 
 export async function getFrontendTimer(
     timersService: TimersService,
@@ -30,4 +30,36 @@ export async function getFrontendTimer(
         }
         return [];
     }
+}
+
+export async function getFrontendTimersBatch(
+    timersService: TimersService,
+    entityType: string,
+    entityIds: number[],
+    stage?: string
+): Promise<Map<number, FrontendTimerData & { deadline: Date | null; allocatedHours: number | null }>> {
+    const timerMap = stage
+        ? await timersService.getTimersByEntityIds(entityType, entityIds, stage)
+        : new Map();
+
+    const result = new Map<number, FrontendTimerData & { deadline: Date | null; allocatedHours: number | null }>();
+
+    for (const entityId of entityIds) {
+        const timer = timerMap.get(entityId);
+        let deadline: Date | null = null;
+        let allocatedHours: number | null = null;
+        let frontendData: FrontendTimerData;
+
+        if (timer) {
+            frontendData = transformTimerForFrontend(timer, stage);
+            deadline = timer.deadlineAt || null;
+            allocatedHours = timer.allocatedTimeMs ? timer.allocatedTimeMs / (1000 * 60 * 60) : null;
+        } else {
+            frontendData = transformTimerForFrontend(null, stage);
+        }
+
+        result.set(entityId, { ...frontendData, deadline, allocatedHours });
+    }
+
+    return result;
 }

--- a/api/src/modules/timers/timers.service.ts
+++ b/api/src/modules/timers/timers.service.ts
@@ -1,10 +1,10 @@
-import { Injectable, Inject, BadRequestException, NotFoundException, ConflictException, Logger } from '@nestjs/common';
-import { eq, and, sql } from 'drizzle-orm';
-import { DRIZZLE } from '@db/database.module';
-import { timerTrackers, timerEvents } from '@db/schemas/workflow/timer.schema';
-import { StartTimerInput, TimerActionInput, ExtendTimerInput, TimerWithComputed, hoursToMs } from './timer.types';
-import type { TimerTracker, TimerEvent } from '@db/schemas/workflow/timer.schema';
 import type { DbInstance } from '@/db';
+import { DRIZZLE } from '@db/database.module';
+import type { TimerTracker } from '@db/schemas/workflow/timer.schema';
+import { timerEvents, timerTrackers } from '@db/schemas/workflow/timer.schema';
+import { BadRequestException, ConflictException, Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import { ExtendTimerInput, StartTimerInput, TimerActionInput, TimerWithComputed, hoursToMs } from './timer.types';
 
 @Injectable()
 export class TimersService {
@@ -372,6 +372,31 @@ export class TimersService {
             .orderBy(timerTrackers.createdAt);
 
         return timers.map(t => this.computeTimer(t));
+    }
+
+    async getTimersByEntityIds(entityType: string, entityIds: number[], stage?: string): Promise<Map<number, TimerWithComputed>> {
+        if (entityIds.length === 0) {
+            return new Map();
+        }
+
+        const conditions = [
+            eq(timerTrackers.entityType, entityType),
+            inArray(timerTrackers.entityId, entityIds),
+        ];
+        if (stage) {
+            conditions.push(eq(timerTrackers.stage, stage));
+        }
+
+        const timers = await this.db
+            .select()
+            .from(timerTrackers)
+            .where(and(...conditions));
+
+        const timerMap = new Map<number, TimerWithComputed>();
+        for (const timer of timers) {
+            timerMap.set(timer.entityId, this.computeTimer(timer));
+        }
+        return timerMap;
     }
 
     async getActiveTimers(entityType: string, entityId: number): Promise<TimerWithComputed[]> {


### PR DESCRIPTION
Add a batch timer lookup method and use it in the dashboard controller to replace the per-tender N+1 queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard pages now load timer information in batches, improving performance across tender-related views.
  * Timer details continue to appear on dashboard items, with results matched more efficiently for each tender.

* **Bug Fixes**
  * Reduced repeated timer lookups, helping dashboards load more smoothly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->